### PR TITLE
Fix: Examples and BigEndian dpx read problem

### DIFF
--- a/pydpx_meta/__init__.py
+++ b/pydpx_meta/__init__.py
@@ -20,7 +20,7 @@ class DpxHeader:
             fp.readinto(_header)
             fp.close()
 
-            if _header.FileHeader.Magic != 'SDPX':
+            if _header.FileHeader.Magic != b'SDPX':
                 _header = low_header_little_endian.DpxHeaderLittleEndian()
                 self._is_big_endian = False
                 fp = open(file_path, "rb")

--- a/pydpx_meta/header.py
+++ b/pydpx_meta/header.py
@@ -832,8 +832,8 @@ class _DpxIndustryTelevisionInfoHeader:
 
     @time_code.setter
     def time_code(self, time_code):
-        time_code = time_code.lower()
-        time_code_hex = "".join(time_code.split(":"))
+        time_code = str(time_code.lower())
+        time_code_hex = "".join(str(time_code.split(":")))
         tc_dpx = int(time_code_hex, 16)
         self._raw_header.TvHeader.TimeCode = tc_dpx
 

--- a/pydpx_meta/header.py
+++ b/pydpx_meta/header.py
@@ -825,9 +825,12 @@ class _DpxIndustryTelevisionInfoHeader:
     @property
     def time_code(self):
         time_code_tmp = '{0:0>8x}'.format(self._raw_header.TvHeader.TimeCode)
-        time_code_str = "{0}:{1}:{2}:{3}".format(time_code_tmp[0:2], time_code_tmp[2:4], time_code_tmp[4:6],
-                                                 time_code_tmp[6:8])
-
+        if self._raw_header.FileHeader.Magic == b'XPDS':
+            time_code_str = "{0}:{1}:{2}:{3}".format(time_code_tmp[0:2], time_code_tmp[2:4], time_code_tmp[4:6],
+                                                     time_code_tmp[6:8])
+        else:
+            time_code_str = "{3}:{2}:{1}:{0}".format(time_code_tmp[0:2], time_code_tmp[2:4], time_code_tmp[4:6],
+                                                     time_code_tmp[6:8])
         return str(time_code_str)
 
     @time_code.setter

--- a/pydpx_meta/header.py
+++ b/pydpx_meta/header.py
@@ -825,12 +825,8 @@ class _DpxIndustryTelevisionInfoHeader:
     @property
     def time_code(self):
         time_code_tmp = '{0:0>8x}'.format(self._raw_header.TvHeader.TimeCode)
-        if self._raw_header.FileHeader.Magic == b'XPDS':
-            time_code_str = "{0}:{1}:{2}:{3}".format(time_code_tmp[0:2], time_code_tmp[2:4], time_code_tmp[4:6],
-                                                     time_code_tmp[6:8])
-        else:
-            time_code_str = "{3}:{2}:{1}:{0}".format(time_code_tmp[0:2], time_code_tmp[2:4], time_code_tmp[4:6],
-                                                     time_code_tmp[6:8])
+        time_code_str = "{0}:{1}:{2}:{3}".format(time_code_tmp[0:2], time_code_tmp[2:4], time_code_tmp[4:6],
+                                                 time_code_tmp[6:8])
         return str(time_code_str)
 
     @time_code.setter

--- a/sample1.py
+++ b/sample1.py
@@ -5,41 +5,41 @@ dpx = pydpx_meta.DpxHeader("/root/V14_37_26_01_v001.0186.dpx")
 # dpx = pydpx_meta.DpxHeader()
 
 # normal access
-print dpx.file_header.magic
-print dpx.file_header.image_offset
-print dpx.image_header.image_element[0].data_sign
-print dpx.tv_header.time_code
-print dpx.tv_header.frame_rate
+print(dpx.file_header.magic)
+print(dpx.file_header.image_offset)
+print(dpx.image_header.image_element[0].data_sign)
+print(dpx.tv_header.time_code)
+print(dpx.tv_header.frame_rate)
 
 # edit and save sample
-print "- edit and save sample -"
+print("- edit and save sample -")
 # change time code
-print dpx.tv_header.time_code
+print(dpx.tv_header.time_code)
 dpx.tv_header.time_code = "01:23:45:12"
-print dpx.tv_header.time_code
+print(dpx.tv_header.time_code)
 # change orientation
 dpx.raw_header.ImageHeader.Orientation = 2
 # commit change
 dpx.save("/root/test.dpx")
 
 # header table direct access
-print dpx.raw_header.FileHeader.Magic
-print dpx.raw_header.FileHeader.ImageOffset
-print dpx.raw_header.FileHeader.Version
-print dpx.raw_header.FileHeader.FileSize
-print dpx.raw_header.FileHeader.DittoKey
-print dpx.raw_header.FileHeader.IndustrySize
-print dpx.raw_header.FileHeader.UserSize
-print dpx.raw_header.FileHeader.FileName
-print dpx.raw_header.FileHeader.TimeDate
-print dpx.raw_header.FileHeader.Creator
-print dpx.raw_header.FileHeader.Project
-print dpx.raw_header.ImageHeader.Orientation
-print dpx.raw_header.ImageHeader.NumberElements
-print dpx.raw_header.ImageHeader.ImageElement[0].Description
+print(dpx.raw_header.FileHeader.Magic)
+print(dpx.raw_header.FileHeader.ImageOffset)
+print(dpx.raw_header.FileHeader.Version)
+print(dpx.raw_header.FileHeader.FileSize)
+print(dpx.raw_header.FileHeader.DittoKey)
+print(dpx.raw_header.FileHeader.IndustrySize)
+print(dpx.raw_header.FileHeader.UserSize)
+print(dpx.raw_header.FileHeader.FileName)
+print(dpx.raw_header.FileHeader.TimeDate)
+print(dpx.raw_header.FileHeader.Creator)
+print(dpx.raw_header.FileHeader.Project)
+print(dpx.raw_header.ImageHeader.Orientation)
+print(dpx.raw_header.ImageHeader.NumberElements)
+print(dpx.raw_header.ImageHeader.ImageElement[0].Description)
 
-print dpx.raw_header.OrientHeader.XOriginalSize
-print dpx.raw_header.OrientHeader.YOriginalSize
-print dpx.raw_header.TvHeader.TimeCode
-print dpx.raw_header.TvHeader.UserBits
-print dpx.raw_header.TvHeader.FrameRate
+print(dpx.raw_header.OrientHeader.XOriginalSize)
+print(dpx.raw_header.OrientHeader.YOriginalSize)
+print(dpx.raw_header.TvHeader.TimeCode)
+print(dpx.raw_header.TvHeader.UserBits)
+print(dpx.raw_header.TvHeader.FrameRate)

--- a/sample2_ex.py
+++ b/sample2_ex.py
@@ -3,4 +3,4 @@ import pydpx_meta
 # High level class DpxHeaderEx sample
 #dpx = pydpx_meta.DpxHeaderEx("/root/V14_37_26_01_v001.0186.dpx")
 dpx = pydpx_meta.DpxHeaderEx()
-print dpx.describe()
+print(dpx.describe())

--- a/sample3_tc.py
+++ b/sample3_tc.py
@@ -5,17 +5,18 @@ import glob
 files = []
 
 # time code sample
-files = glob.glob("/root/test/*.dpx")
+# files = glob.glob("/root/test/*.dpx")
+files = glob.glob("/Volumes/Rapid_TEST_SSD/src/A001_C014_1218UE_TEST/_sawa2/*.dpx")
 files = sorted(files)
 
-print "-------------------"
+print("-------------------")
 
 # display time code
 for file in files:
     dpx = pydpx_meta.DpxHeader(file)
-    print dpx.tv_header.time_code
+    print(dpx.tv_header.time_code)
 
-print "-------------------"
+print("-------------------")
 
 # increment 1 frame to time code
 dpx = pydpx_meta.DpxHeader(files[0])
@@ -27,4 +28,4 @@ for file in files:
     dpx = pydpx_meta.DpxHeader(file)
     tc += delta_tc
     dpx.tv_header.time_code = tc
-    print dpx.tv_header.time_code
+    print(dpx.tv_header.time_code)

--- a/sample3_tc.py
+++ b/sample3_tc.py
@@ -5,8 +5,7 @@ import glob
 files = []
 
 # time code sample
-# files = glob.glob("/root/test/*.dpx")
-files = glob.glob("/Volumes/Rapid_TEST_SSD/src/A001_C014_1218UE_TEST/_sawa2/*.dpx")
+files = glob.glob("/root/test/*.dpx")
 files = sorted(files)
 
 print("-------------------")


### PR DESCRIPTION
Hello plinecom

I have also modified the example, so please check it.

In sample3_tc.py, timecode encountered an error related to str.
It seems to be related to str problem of python 2..x.
For now I fixed it, so please review.

so, for the next time, I will pull in a lump.
Although it is an example but I think that it isn't good to doesn't work in python 3.x,
I pushed it in a hurry:)
Thank you.